### PR TITLE
Develop

### DIFF
--- a/example/gmsh/t8_read_msh_file.cxx
+++ b/example/gmsh/t8_read_msh_file.cxx
@@ -154,7 +154,9 @@ main (int argc, char *argv[])
   }
   else {
     cmesh = t8_read_msh_file_build_cmesh (prefix, partition, dim, master);
-    t8_cmesh_destroy (&cmesh);
+    if (cmesh != NULL) {
+      t8_cmesh_destroy (&cmesh);
+    }
     sc_options_print_summary (t8_get_package_id (), SC_LP_PRODUCTION, opt);
   }
 

--- a/example/gmsh/t8_read_msh_file.cxx
+++ b/example/gmsh/t8_read_msh_file.cxx
@@ -154,6 +154,7 @@ main (int argc, char *argv[])
   }
   else {
     cmesh = t8_read_msh_file_build_cmesh (prefix, partition, dim, master);
+    /* Check whether we could properly read the cmesh and if so, destroy it. */
     if (cmesh != NULL) {
       t8_cmesh_destroy (&cmesh);
     }


### PR DESCRIPTION
The gmsh example passed a possible NULL return from the msh file reading function on to cmesh_destroy.
However, cmesh_destroy should only be called with a valid cmesh and passing NULL triggered an assertion.
The call is now guarded by an if.

Together with the upcoming file version and type check of gmsh files, the gmsh example should now run smoothly without  crashing even in the case of wrong input (non-existing file, wrong file version, wrong file type).